### PR TITLE
fix: Set cursor to the correct style

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -202,6 +202,7 @@ body {
     right: 0px;
     width: 11%;
     left: 3vh;
+    cursor: pointer; /* Can also be 'none' however, as these are the buttons I feel as the pointer fits better */
 }
 
 .combine-option-container {
@@ -358,6 +359,7 @@ body {
     text-align: right;
     font-size: 1.25vh;
     font-weight: 400;
+    cursor: none;
 }
 
 .item-slot-amount > p:after {
@@ -375,6 +377,7 @@ body {
     text-align: right;
     font-size: 1.25vh;
     font-weight: 400;
+    cursor: none;
 }
 
 .item-slot-label {
@@ -396,6 +399,7 @@ body {
     white-space: pre;
     text-overflow: ellipsis;
     overflow: hidden;
+    cursor: none;
 }
 
 .item-slot-quality {
@@ -460,6 +464,7 @@ body {
     top: 8.6%;
     width: 28.8%;
     z-index: 1000;
+    cursor: none;
 }
 
 #player-inv-label {
@@ -473,6 +478,7 @@ body {
     top: 25px;
     float: left;
     text-transform: normal;
+    cursor: none;
 }
 
 #player-inv-weight {
@@ -498,7 +504,9 @@ body {
     top: 25px;
     float: left;
     text-transform: normal;
+    cursor: none;
 }
+
 
 #other-inv-weight {
     position: relative;
@@ -510,6 +518,7 @@ body {
     bottom: 40px;
     right: -33.5%;
     float: right;
+    cursor: none;
 }
 
 .player-inv-weight {

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -101,6 +101,7 @@ body {
     height: 100%;
     left: 0vw;
     display: none;
+    user-select: none;
 }
 
 .inv-background {


### PR DESCRIPTION
Gets rid of the fancy cursor when hovering over text, also makes the cursor a pointer when hovering over the buttons in the middle