### PR TITLE
Update main.lua fix item lose when inventory full

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1450,6 +1450,37 @@ RegisterServerEvent("inventory:server:GiveItem", function(target, name, amount, 
 	end
 end)
 
+
+RegisterNetEvent("inventory:server:spawnOnGround", function(source, itemData, itemAmount) 
+	local coords = GetEntityCoords(GetPlayerPed(source))
+	local itemInfo = QBCore.Shared.Items[itemData.name:lower()]
+	local dropId = CreateDropId()
+	Drops[dropId] = {}
+	Drops[dropId].items = {}
+
+	Drops[dropId].items[1] = {
+		name = itemInfo["name"],
+		amount = itemAmount,
+		info = itemData.info ~= nil and itemData.info or "",
+		label = itemInfo["label"],
+		description = itemInfo["description"] ~= nil and itemInfo["description"] or "",
+		weight = itemInfo["weight"],
+		type = itemInfo["type"],
+		unique = itemInfo["unique"],
+		useable = itemInfo["useable"],
+		image = itemInfo["image"],
+		slot = 1,
+		id = dropId,
+	}
+	local Ply = QBCore.Functions.GetPlayer(source)
+	TriggerEvent("qb-log:server:CreateLog", "drop", "New Item Spawn as Drop", "red", "**".. GetPlayerName(source) .. "** (citizenid: *"..Ply.PlayerData.citizenid.."* | id: *"..source.."*) overflowed inventory into drop; name: **"..itemData.name.."**, amount: **" .. itemAmount .. "**")
+	TriggerClientEvent("inventory:client:AddDropItem", -1, dropId, source, coords)
+end)
+
+
+
+
+
 -- callback
 
 QBCore.Functions.CreateCallback('qb-inventory:server:GetStashItems', function(source, cb, stashId)

--- a/server/main.lua
+++ b/server/main.lua
@@ -19,6 +19,9 @@ local function recipeContains(recipe, fromItem)
 	return false
 end
 
+
+
+
 local function hasCraftItems(source, CostItems, amount)
 	local Player = QBCore.Functions.GetPlayer(source)
 	for k, v in pairs(CostItems) do
@@ -1450,37 +1453,6 @@ RegisterServerEvent("inventory:server:GiveItem", function(target, name, amount, 
 	end
 end)
 
-
-RegisterNetEvent("inventory:server:spawnOnGround", function(source, itemData, itemAmount) 
-	local coords = GetEntityCoords(GetPlayerPed(source))
-	local itemInfo = QBCore.Shared.Items[itemData.name:lower()]
-	local dropId = CreateDropId()
-	Drops[dropId] = {}
-	Drops[dropId].items = {}
-
-	Drops[dropId].items[1] = {
-		name = itemInfo["name"],
-		amount = itemAmount,
-		info = itemData.info ~= nil and itemData.info or "",
-		label = itemInfo["label"],
-		description = itemInfo["description"] ~= nil and itemInfo["description"] or "",
-		weight = itemInfo["weight"],
-		type = itemInfo["type"],
-		unique = itemInfo["unique"],
-		useable = itemInfo["useable"],
-		image = itemInfo["image"],
-		slot = 1,
-		id = dropId,
-	}
-	local Ply = QBCore.Functions.GetPlayer(source)
-	TriggerEvent("qb-log:server:CreateLog", "drop", "New Item Spawn as Drop", "red", "**".. GetPlayerName(source) .. "** (citizenid: *"..Ply.PlayerData.citizenid.."* | id: *"..source.."*) overflowed inventory into drop; name: **"..itemData.name.."**, amount: **" .. itemAmount .. "**")
-	TriggerClientEvent("inventory:client:AddDropItem", -1, dropId, source, coords)
-end)
-
-
-
-
-
 -- callback
 
 QBCore.Functions.CreateCallback('qb-inventory:server:GetStashItems', function(source, cb, stashId)
@@ -1647,4 +1619,31 @@ QBCore.Functions.CreateUseableItem("id_card", function(source, item)
 			)
 		end
 	end
+end)
+
+
+RegisterNetEvent("inventory:server:spawnOnGround", function(source, itemData, itemAmount) 
+	local coords = GetEntityCoords(GetPlayerPed(source))
+	local itemInfo = QBCore.Shared.Items[itemData.name:lower()]
+	local dropId = CreateDropId()
+	Drops[dropId] = {}
+	Drops[dropId].items = {}
+
+	Drops[dropId].items[1] = {
+		name = itemInfo["name"],
+		amount = itemAmount,
+		info = itemData.info ~= nil and itemData.info or "",
+		label = itemInfo["label"],
+		description = itemInfo["description"] ~= nil and itemInfo["description"] or "",
+		weight = itemInfo["weight"],
+		type = itemInfo["type"],
+		unique = itemInfo["unique"],
+		useable = itemInfo["useable"],
+		image = itemInfo["image"],
+		slot = 1,
+		id = dropId,
+	}
+	local Ply = QBCore.Functions.GetPlayer(source)
+	TriggerEvent("qb-log:server:CreateLog", "drop", "New Item Spawn as Drop", "red", "**".. GetPlayerName(source) .. "** (citizenid: *"..Ply.PlayerData.citizenid.."* | id: *"..source.."*) overflowed inventory into drop; name: **"..itemData.name.."**, amount: **" .. itemAmount .. "**")
+	TriggerClientEvent("inventory:client:AddDropItem", -1, dropId, source, coords)
 end)


### PR DESCRIPTION
Add event to drop on ground when you are given item and you inventory is full 

need newer qbcore version or you need to make a change in 

qb-core/server/player.lua

replace  line 355 

TriggerClientEvent('QBCore:Notify', self.PlayerData.source, 'Your inventory is too heavy!', 'error')


with

 

            TriggerEvent("inventory:server:spawnOnGround", self.PlayerData.source, { name = itemInfo['name'], amount = amount, info = info or '', label = itemInfo['label'], description = itemInfo['description'] or '', weight = itemInfo['weight'], type = itemInfo['type'], unique = itemInfo['unique'], useable = itemInfo['useable'], image = itemInfo['image'], shouldClose = itemInfo['shouldClose'], slot = slot, combinable = itemInfo['combinable'] }, amount)
            TriggerClientEvent('QBCore:Notify', self.PlayerData.source, 'Your inventory is too heavy, placing item on floor!', 'error')

**Pull Request Description**

_Please include a general description of the changes made, why they were necessary, 
and any other general things to note._

**Pull Request Checklist**:
* [ x] Have you followed the guidelines in our contributing document and Code of Conduct?
* [ x] Have you checked to ensure there aren't other open for the same update/change?
* [ x] Have you built and tested the `resource` in-game after the relevant change?
