### PR TITLE
QOL Enhancements

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -414,25 +414,54 @@ end)
 
 RegisterNetEvent('inventory:client:OpenInventory', function(PlayerAmmo, inventory, other)
     if not IsEntityDead(PlayerPedId()) then
-        Wait(500)
-        ToggleHotbar(false)
-        if showBlur == true then
-            TriggerScreenblurFadeIn(1000)
+        if Config.Progressbar.Enable then
+            QBCore.Functions.Progressbar('open_inventory', 'Opening Inventory...', math.random(Config.Progressbar.minT, Config.Progressbar.maxT), false, true, { -- Name | Label | Time | useWhileDead | canCancel
+                disableMovement = false,
+                disableCarMovement = false,
+                disableMouse = false,
+                disableCombat = false,
+            }, {}, {}, {}, function() -- Play When Done
+                ToggleHotbar(false)
+                if showBlur == true then
+                    TriggerScreenblurFadeIn(1000)
+                end
+                SetNuiFocus(true, true)
+                if other then
+                    currentOtherInventory = other.name
+                end
+                SendNUIMessage({
+                    action = "open",
+                    inventory = inventory,
+                    slots = Config.MaxInventorySlots,
+                    other = other,
+                    maxweight = Config.MaxInventoryWeight,
+                    Ammo = PlayerAmmo,
+                    maxammo = Config.MaximumAmmoValues,
+                })
+                inInventory = true
+                end, function() -- Play When Cancel
+            end)
+        else
+            Wait(500)
+            ToggleHotbar(false)
+            if showBlur == true then
+                TriggerScreenblurFadeIn(1000)
+            end
+            SetNuiFocus(true, true)
+            if other then
+                currentOtherInventory = other.name
+            end
+            SendNUIMessage({
+                action = "open",
+                inventory = inventory,
+                slots = Config.MaxInventorySlots,
+                other = other,
+                maxweight = Config.MaxInventoryWeight,
+                Ammo = PlayerAmmo,
+                maxammo = Config.MaximumAmmoValues,
+            })
+            inInventory = true
         end
-        SetNuiFocus(true, true)
-        if other then
-            currentOtherInventory = other.name
-        end
-        SendNUIMessage({
-            action = "open",
-            inventory = inventory,
-            slots = Config.MaxInventorySlots,
-            other = other,
-            maxweight = Config.MaxInventoryWeight,
-            Ammo = PlayerAmmo,
-            maxammo = Config.MaximumAmmoValues,
-        })
-        inInventory = true
     end
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -796,7 +796,7 @@ RegisterKeyMapping('hotbar', 'Toggles keybind slots', 'keyboard', 'z')
 
 for i = 1, 6 do
     RegisterCommand('slot' .. i,function()
-        if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
+        if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() and not LocalPlayer.state.inv_busy then
             if i == 6 then
                 i = Config.MaxInventorySlots
             end

--- a/client/main.lua
+++ b/client/main.lua
@@ -668,6 +668,7 @@ RegisterNetEvent("qb-inventory:client:closeinv", function()
 end)
 
 RegisterCommand('inventory', function()
+    if IsNuiFocused() then return end
     if not isCrafting and not inInventory then
         if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
             local ped = PlayerPedId()

--- a/config.lua
+++ b/config.lua
@@ -10,6 +10,12 @@ Config.MaxDropViewDistance = 12.5 -- The distance in GTA Units that a drop can b
 Config.UseItemDrop = false -- This will enable item object to spawn on drops instead of markers
 Config.ItemDropObject = `sf_prop_sf_backpack_01a` -- if Config.UseItemDrop is true, this will be the prop that spawns for the item
 
+Config.Progressbar = {
+    Enable = false,         -- True to Enable the progressbar while opening inventory
+    minT = 350,             -- Min Time for Inventory to open
+    maxT = 500              -- Max Time for Inventory to open
+}
+
 Config.VendingObjects = {
     "prop_vend_soda_01",
     "prop_vend_soda_02",

--- a/server/main.lua
+++ b/server/main.lua
@@ -1484,7 +1484,7 @@ RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, to
 				AddToStash(stashId, toSlot, fromSlot, itemInfo["name"], fromAmount, fromItemData.info)
 			elseif QBCore.Shared.SplitStr(toInventory, "-")[1] == "traphouse" then
 				-- Traphouse
-				local traphouseId = QBCore.Shared.SplitStr(toInventory, "-")[2]
+				local traphouseId = QBCore.Shared.SplitStr(toInventory, "_")[2]
 				local toItemData = exports['qb-traphouse']:GetInventoryData(traphouseId, toSlot)
 				local IsItemValid = exports['qb-traphouse']:CanItemBeSaled(fromItemData.name:lower())
 				if IsItemValid then


### PR DESCRIPTION
### Changes are done are for following as mentioned below -


**1.** Added a Progressbar toggle to inventory opening so if people wanna have something new or increase delay in opening then switch to this.

**2.** Added _Condition in hotbar_ usage so this avoids alot of item duplication/exploits

**3.**  This prevents the inventory opening if another resource already has NUI focus. This was occurring if a user used `/tx` to open the tx admin, which uses TAB to cycle through the menu.

**4.** There is a problem obtaining the traphouse id. The symbol used on the string split is wrong.