### PR TITLE
(fix) not deleting items if first slot is lower

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -226,6 +226,9 @@ local function RemoveItem(source, item, amount, slot)
 			TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'RemoveItem', 'red', '**' .. GetPlayerName(source) .. ' (citizenid: ' .. Player.PlayerData.citizenid .. ' | id: ' .. source .. ')** lost item: [slot:' .. slot .. '], itemname: ' .. item .. ', removed amount: ' .. amount .. ', item removed')
 
 			return true
+		elseif Player.PlayerData.items[_slot].amount < amountToRemove then
+			amountToRemove = amountToRemove - Player.PlayerData.items[_slot].amount
+			Player.PlayerData.items[_slot] = nil
 		end
 	else
 		local slots = GetSlotsByItem(Player.PlayerData.items, item)


### PR DESCRIPTION
Found this bug in my server, where, in case you had 1 slot with an amount under the total amount to remove, (for example, 1 in slot1 and 4 in slot 4, try to remove 5), it would return true but not remove anything. This fixes it by removing the first slot and continuing without updating the inventory. This way, if the total amount in all slots is under the amount to remove, it would not finish removing and simply return false.

**Pull Request Checklist**:
* [x] Have you followed the guidelines in our contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open for the same update/change?
* [X] Have you built and tested the `resource` in-game after the relevant change?
